### PR TITLE
Fixed Dark Lake Hylia shop location in Shop Shuffle

### DIFF
--- a/OpenTracker.Models/Locations/MapLocationFactory.cs
+++ b/OpenTracker.Models/Locations/MapLocationFactory.cs
@@ -1342,7 +1342,7 @@ namespace OpenTracker.Models.Locations
                 },
                 LocationID.DarkLakeHyliaShop => new List<IMapLocation>
                 {
-                    _factory(MapID.DarkWorld, 1460, 1540, location,
+                    _factory(MapID.DarkWorld, 1300, 1618, location,
                         _requirements[RequirementType.TakeAnyLocationsOrShopShuffleEntranceShuffleNoneDungeon])
                 },
                 LocationID.DarkPotionShop => new List<IMapLocation>


### PR DESCRIPTION
The location for the Dark World Lake Hylia shop is supposed to be on the building, not in the cave entrance.