### PR TITLE
Fix old man without entrance shuffle

### DIFF
--- a/OpenTracker.Models/Locations/Map/MapLocationFactory.cs
+++ b/OpenTracker.Models/Locations/Map/MapLocationFactory.cs
@@ -218,6 +218,7 @@ namespace OpenTracker.Models.Locations.Map
                         {
                             _alternativeRequirements[new HashSet<IRequirement>
                             {
+                                _entranceShuffleRequirements[EntranceShuffle.None],
                                 _entranceShuffleRequirements[EntranceShuffle.All],
                                 _entranceShuffleRequirements[EntranceShuffle.Insanity]
                             }],


### PR DESCRIPTION
My tracker did not show "Old Man" at all.

I don't really know how the software works at all. By trial and error (and some educated guessing) I think that I found the root cause. Seems like the un-shuffled non-inverted setting was missing in the location factory.